### PR TITLE
Allow collecting logs also for Helm 4.

### DIFF
--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -41,13 +41,13 @@ if [ -z "${PODS}" ]; then
 fi
 
 # Get Helm version since 'helm list' on Helm 3 does not display all namespaces unless specified. However, this flag does not exist in Helm 2
-case X`helm version --template="{{.Version}}"` in
-  Xv3.*)
-    HELM_COMMAND="$HELM list --all-namespaces";;
-  *)
-    echo "Trend Micro Vision One Container Security only supports Helm 3 or newer version, exiting..."
-    exit 1
-esac
+HELM_VERSION=$(helm version --template="{{.Version}}" | sed 's/^v\([0-9]*\).*/\1/')
+if [ "$HELM_VERSION" -ge 3 ]; then
+  HELM_COMMAND="$HELM list --all-namespaces"
+else
+  echo "Trend Micro Vision One Container Security only supports Helm 3 or newer version, exiting..."
+  exit 1
+fi
 
 
 # prepare the output folder


### PR DESCRIPTION
close https://github.com/trendmicro/visionone-container-security-helm/issues/7

Script to collect logs checks Helm version and assumes that only versions 2 and 3 exists. 

When I modified the check to allow v4 it seems to work just fine. 